### PR TITLE
added data_account parameter to work with feature accounts!

### DIFF
--- a/bentodev/cli.py
+++ b/bentodev/cli.py
@@ -67,12 +67,13 @@ def clone(slug):
 
 @cli.command('start')
 @click.argument('account', required=False)
-def start(account):
+@click.argument('data_account', required=False)
+def start(account, data_account):
     """Begin running the development server"""
     token = get_token()
     if account:
         repo = get_theme(token, account)
-        run_flask(account, repo)
+        run_flask(account, repo, data_account)
     else:
         list_accounts(token, ListFlags.START)
 

--- a/bentodev/utils/command_functions.py
+++ b/bentodev/utils/command_functions.py
@@ -102,13 +102,13 @@ def list_accounts(token, flag=None):
                     slug, theme_name, status, WIDTH))
 
 
-def run_flask(account, theme):
+def run_flask(account, theme, data_account=None):
     user_settings = set_user_settings()
     cloned_themes = get_cloned_themes()
     if theme not in cloned_themes:
         print("Theme `{}` has not been cloned!".format(theme))
         raise SystemExit
-    main(theme, account, user_settings)
+    main(theme, account, user_settings, data_account)
 
 
 def clone_repo(token, slug):

--- a/bentodev/utils/server.py
+++ b/bentodev/utils/server.py
@@ -68,10 +68,14 @@ def create_app():
     return app
 
 
-def set_globals(theme, account, user_settings):
-    global THEME, ACCOUNT, BENTODEV_URSER_DIR, REPO_DIR, STATIC_DIR, TEMPLATE_DIR, SCSS_DIR, LOCAL_HOST, LOCAL_PORT, LOCAL_URL
+def set_globals(theme, account, user_settings, data_account=None):
+    global THEME, ACCOUNT, DATA_ACCOUNT, BENTODEV_URSER_DIR, REPO_DIR, STATIC_DIR, TEMPLATE_DIR, SCSS_DIR, LOCAL_HOST, LOCAL_PORT, LOCAL_URL
     THEME = theme
     ACCOUNT = account
+    if data_account:
+        DATA_ACCOUNT = data_account
+    else:
+        DATA_ACCOUNT = account
     if 'DEV_ROOT' in user_settings:
         BENTODEV_URSER_DIR = user_settings['DEV_ROOT']
     REPO_DIR = os.path.join(BENTODEV_URSER_DIR, 'sites', THEME)
@@ -85,8 +89,8 @@ def set_globals(theme, account, user_settings):
     LOCAL_URL = 'http://{}:{}/'.format(LOCAL_HOST, LOCAL_PORT)
 
 
-def main(theme, account, user_settings):
-    set_globals(theme, account, user_settings)
+def main(theme, account, user_settings, data_account=None):
+    set_globals(theme, account, user_settings, data_account)
     app = create_app()
     app.run(host=LOCAL_HOST, port=int(LOCAL_PORT))
 
@@ -100,7 +104,7 @@ def handle_request(path):
         'sessionid': CURRENT_SESSION_ID
     }
     kwargs = {
-        'account': ACCOUNT,
+        'account': DATA_ACCOUNT,
         'path': path,
         'help': True,
         'cookies': cookies


### PR DESCRIPTION
With the old bentodev app, it's not possible to work with feature account.
```
$ bentodev start nextdooreatery-updating                             // Not working!
```

So I have created a new optional parameter called `data_account`. Now I can use it like below:
```
$ bentodev start nextdooreatery nextdooreatery-updating
```
Then all `?help` requests go to data_account!

**It's the easiest update for the feature account, isn't it?** 😉 