### PR TITLE
Jimmy White updates

### DIFF
--- a/bentodev/cli.py
+++ b/bentodev/cli.py
@@ -72,7 +72,7 @@ def start(account, data_account):
     """Begin running the development server"""
     token = get_token()
     if account:
-        repo = get_theme(token, account)
+        repo = get_theme(token, account, data_account)
         run_flask(account, repo, data_account)
     else:
         list_accounts(token, ListFlags.START)

--- a/bentodev/utils/command_functions.py
+++ b/bentodev/utils/command_functions.py
@@ -40,9 +40,9 @@ def set_user_settings():
     return user_settings
 
 
-def get_theme(token, account):
+def get_theme(token, account, data_account=None):
     kwargs = {
-        'account': account,
+        'account': data_account if data_account else account,
         'help': True,
         'token': token
     }

--- a/bentodev/utils/image_utils.py
+++ b/bentodev/utils/image_utils.py
@@ -73,7 +73,7 @@ def generate_resize_url(source, width=1200, height=None, fit='max'):
     if height:
         params += "&h=%i" % int(height)
 
-    url = '%s%s?%s' % (IMGIX_URL, source, params)
+    url = '%s?%s' % (source, params)
 
     return url
 
@@ -81,5 +81,4 @@ def generate_resize_url(source, width=1200, height=None, fit='max'):
 def get_raw_image_url(source):
     source = get_base_source(source)
 
-    url = '%s%s' % (IMGIX_URL, source)
-    return url
+    return source


### PR DESCRIPTION
Made some quick updates to the bentodev.

- When it generates the `api/account` url, now it uses `data_account` in case of `getbento.com`.
- Removed `IMGIX` from the `generate_resize_url` and the `get_raw_image_url` functions.

Happy merge!